### PR TITLE
small changes for compatibility with racket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 artifact35-auas7pp.tar
 shared
+*~

--- a/src/evalo-optimized.scm
+++ b/src/evalo-optimized.scm
@@ -576,7 +576,6 @@
         (eval-begino
           (cons `(,name (lambda ,args ,body)) rec-defs) begin-rest env val)))))
 
-(define empty-env '())
 
 (define (lookup-reco k renv x b* t)
     (conde

--- a/src/mk/test-interp.scm
+++ b/src/mk/test-interp.scm
@@ -1,6 +1,7 @@
 (load "test-check.scm")
 (load "mk.scm")
 
+;; eval-expo relies on the mutable variable lookupo as a helper function.
 (define eval-expo
   (lambda (exp env val)
     (conde
@@ -25,6 +26,7 @@
          (=/= y x)
          (not-in-envo x rest))))))
 
+;; MUTABLE!
 (define lookupo
   (lambda (x env t)
     (conde
@@ -49,7 +51,9 @@
       (lambda (z) z))
      (sym _.0))))
 
-(define lookupo
+;; Mutate lookupo, the evalo tests after this rely on this new version.
+(set!
+  lookupo
   (lambda (x env t)
     (fresh (rest y v)
       (== `((,y . ,v) . ,rest) env)


### PR DESCRIPTION
evalo-optimized: get rid of unnecessary redefinition

test-interp: turn redefinition / implicit mutation into explicit mutation